### PR TITLE
pin nbgitpuller

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -36,7 +36,7 @@ dependencies:
   - jupyterlab=3
   - jupyter-resource-usage
   - matplotlib
-  - nbgitpuller
+  - nbgitpuller=0.9
   - numpy
   - pandas
   - panel


### PR DESCRIPTION
nbgitpuller 0.10 had some changes that don't work with out binder config (having `.binder/Dockerfile` in snowex website repository, which admitedly is confusing, but allows pointing to a specific build tag rather than the main branch of this repository). But the problem seems to be using a dockerfile to specify the environment, then nbgitpuller to pull the same repo and branch for content. I think this is a bug, so should open an issue in nbgitpuller repo, but the short-term solution i think is just to pin.

https://gke.mybinder.org/v2/gh/snowex-hackweek/website/main?urlpath=git-pull%3Frepo%3Dhttps%253A%252F%252Fgithub.com%252Fsnowex-hackweek%252Fwebsite%26urlpath%3Dlab%252Ftree%252Fwebsite%252Fbook%252Ftutorials%26branch%3Dmain

```pytb
Traceback (most recent call last):
File "/srv/conda/envs/notebook/lib/python3.8/site-packages/nbgitpuller/pull.py", line 90, in branch_exists
    heads = subprocess.run(
File "/srv/conda/envs/notebook/lib/python3.8/subprocess.py", line 516, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['git', 'ls-remote', '--heads', 'https://github.com/snowex-hackweek/website']' returned non-zero exit status 128.
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
File "/srv/conda/envs/notebook/lib/python3.8/site-packages/nbgitpuller/handlers.py", line 76, in get
    gp = GitPuller(repo, repo_dir, branch=branch, depth=depth, parent=self.settings['nbapp'])
File "/srv/conda/envs/notebook/lib/python3.8/site-packages/nbgitpuller/pull.py", line 77, in __init__
    elif not self.branch_exists(self.branch_name):
File "/srv/conda/envs/notebook/lib/python3.8/site-packages/nbgitpuller/pull.py", line 112, in branch_exists
    raise ValueError(m)
ValueError: Problem accessing list of branches and/or tags: https://github.com/snowex-hackweek/website
```