### PR TITLE
install git from conda-forge

### DIFF
--- a/apt.txt
+++ b/apt.txt
@@ -1,4 +1,3 @@
 vim
 wget
-git
 groff

--- a/environment.yml
+++ b/environment.yml
@@ -14,11 +14,12 @@ dependencies:
   - fsspec
   - gcsfs
   - gdal
-  - gh
   - geoalchemy2
   - geojson
   - geopandas
   - geoviews
+  - gh
+  - git
   - h5py
   - holoviews
   - hvplot


### PR DESCRIPTION
git install from apt on ubuntu is quite old (2.17), looks like it can be installed via conda-forge so doing that