### PR TITLE
pin pandas minor version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -41,7 +41,7 @@ dependencies:
   - matplotlib
   - nbgitpuller=0.9
   - numpy
-  - pandas
+  - pandas=1.2
   - panel
   - param>=1.11.1
   - pdal=2.2


### PR DESCRIPTION
pandas just released 1.2 -> 1.3 and it's causing some issues with holoviews: 
```
>>> import holoviews
WARNING:param.main: pandas could not register all extension types imports failed with the following error: cannot import name 'ABCIndexClass' from 'pandas.core.dtypes.generic' (/srv/conda/envs/notebook/lib/python3.8/site-packages/pandas/core/dtypes/generic.py)
```