### PR TITLE
PR workflow - increase AWS key limit for PRs.

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -42,7 +42,7 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
         role-to-assume: github-actions-role
-        role-duration-seconds: 900
+        role-duration-seconds: 2400
 
     # NOTE: this gets picked up b/c of the docker run -v mount
     - name: Configure NASA Earthdata Login


### PR DESCRIPTION
See issue https://github.com/snowex-hackweek/website/issues/115

Increase the limit for the docker image that builds previews for PRs